### PR TITLE
Update vsPagination.vue

### DIFF
--- a/src/components/vsPagination/vsPagination.vue
+++ b/src/components/vsPagination/vsPagination.vue
@@ -1,17 +1,19 @@
 <template>
   <vs-row
     vs-type="flex"
-    vs-justify="space-between"
+    :vs-justify="description ? 'space-between' : 'center'"
     vs-w="12">
     <vs-col
+      v-if="description"
       class="vs-pagination--mb"
       vs-type="flex"
       vs-justify="flex-start"
       vs-align="center"
       vs-lg="6"
       vs-sm="12"
-      vs-xs="12" >
-      <div v-if="description">
+      vs-xs="12" 
+      >
+      <div>
         <span
           style="margin-right:5px"
         >


### PR DESCRIPTION
The pagination style is updated, when the description property is false, it hides the column where the pagination would go, to avoid that the second column with the pagination is traversed and can be centered as in previous versions.